### PR TITLE
sentence does not transcend individual list items

### DIFF
--- a/info/task_description.html
+++ b/info/task_description.html
@@ -19,8 +19,8 @@
 <p>
   <strong>Input:</strong> Two arguments:
   <ul>
-    <li>one-line sentence as a string,</li>
-    <li>max length of the truncated sentence as an int.</li>
+    <li>one-line sentence as a string</li>
+    <li>max length of the truncated sentence as an int</li>
   </ul>
 </p>
 


### PR DESCRIPTION
List items stand for themselves, they aren't part of 1 single sentence.

This was a regression introduced in 13b6868